### PR TITLE
feat: make go-link-shortener agent-native with WebMCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ coverage.*
 *.coverprofile
 profile.cov
 
+# Local Git worktrees
+.worktrees/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,31 @@ GET http://localhost:3000/my-slug
 
 Redirects to the stored target URL.
 
+## WebMCP
+
+The home page exposes the existing creation form as `create_short_link` for
+WebMCP-enabled browsers. It also registers read-only `resolve_short_link` and
+`get_link_analytics` tools. The read tools return the destination or aggregate
+click count and latest click timestamp; they never expose visitor IP addresses,
+User-Agent strings, referrers, or individual click events.
+
+WebMCP is a progressive enhancement: browsers without it continue to use the
+normal form and redirects. It requires an origin-isolated document.
+
+### Test locally
+
+1. In Chrome, enable `chrome://flags/#enable-webmcp-testing` and relaunch.
+2. Start the application and open its home page in Chrome.
+3. Use the Model Context Tool Inspector extension to confirm these tools are
+   discoverable: `create_short_link`, `resolve_short_link`, and
+   `get_link_analytics`.
+4. Ask the agent to create `/webmcp` for
+   `https://developer.chrome.com/docs/ai/webmcp`; it should use the visible
+   form tool rather than clicking through the page.
+5. Ask where `/webmcp` redirects, open the short URL a few times, then ask for
+   traffic. The agent should use the two read-only tools and report aggregate
+   metrics.
+
 ## Environment Variables
 
 | Variable    | Description                                      | Default           |

--- a/docs/superpowers/plans/2026-09-01-webmcp-integration.md
+++ b/docs/superpowers/plans/2026-09-01-webmcp-integration.md
@@ -1,0 +1,92 @@
+# WebMCP Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose URL creation, resolution, and aggregate traffic as WebMCP tools while preserving the Fiber UI.
+
+**Architecture:** Annotate the existing form for declarative WebMCP. Add two JSON read endpoints backed by Redis/PostgreSQL, then conditionally register two imperative browser tools.
+
+**Tech Stack:** Go, Fiber v3, pgx/v5, Redis, PostgreSQL JSONB, JavaScript.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-webmcp-design.md`
+
+## Global Constraints
+
+- Do not add dependencies, frontend frameworks, a build step, deletion, authentication, or a remote MCP server.
+- Keep `CreateLinkForm` as the only creation validation and persistence path.
+- Use `create_short_link`, `resolve_short_link`, and `get_link_analytics`; imperative tools set `annotations.readOnlyHint: true`.
+- Never return IP, User-Agent, referrer, or individual analytics events.
+- Feature-detect `document.modelContext`; normal browser behavior must work without it.
+
+---
+
+## File Structure
+
+- `main.go`: API and script routes before `/:slug`.
+- `internal/database/postgres.go`: link read model and aggregate analytics query.
+- `internal/handlers/api.go`: JSON read handlers.
+- `internal/handlers/link.go`: form metadata and script tag.
+- `web/webmcp.js`: tool registration and fetch errors.
+- `internal/database/postgres_test.go`, `internal/handlers/api_test.go`, `internal/handlers/link_test.go`: focused coverage.
+- `README.md`: Chrome verification instructions.
+
+### Task 1: Database lookup and aggregate models
+
+**Files:** Modify `internal/database/postgres.go`; test `internal/database/postgres_test.go`.
+
+**Interfaces:** Produce `LinkDetails { Slug string; OriginalURL string }`, `LinkAnalytics { TotalClicks int; LastClickedAt *time.Time }`, `GetLinkDetails(*pgxpool.Pool, string)`, and `GetLinkAnalytics(*pgxpool.Pool, string)`.
+
+- [ ] Write a failing decoder test:
+
+```go
+func TestDecodeAnalyticsSummary(t *testing.T) {
+  got, err := decodeAnalyticsSummary([]byte(`[{"timestamp":"2026-09-01T14:20:00Z"},{"timestamp":"2026-09-02T10:00:00Z"}]`))
+  if err != nil || got.TotalClicks != 2 || got.LastClickedAt.Format(time.RFC3339) != "2026-09-02T10:00:00Z" { t.Fatal(got, err) }
+}
+```
+
+- [ ] Run `go test ./internal/database -run TestDecodeAnalyticsSummary -count=1`; expect failure because the decoder is missing.
+- [ ] Implement `GetLinkDetails` using `SELECT slug, original_url FROM links WHERE slug = $1`; query the matching JSONB `analytics`, decode timestamps, return zero/nil for `[]`, and preserve `pgx.ErrNoRows`.
+- [ ] Run `go test ./internal/database -run 'TestDecodeAnalyticsSummary|TestDecodeAnalyticsSummaryEmpty' -count=1`; expect pass.
+- [ ] Commit database changes with `feat: add link lookup and analytics summaries`.
+
+### Task 2: Read-only JSON APIs
+
+**Files:** Create `internal/handlers/api.go`; modify `main.go`; test `internal/handlers/api_test.go`.
+
+**Interfaces:** Consume the task-one database functions and Redis helpers. Produce `Handler.GetLink(fiber.Ctx)` and `Handler.GetLinkAnalytics(fiber.Ctx)`.
+
+- [ ] Write failing endpoint tests for a JSON lookup response containing `alias`, `shortUrl`, `targetUrl`; analytics containing `totalClicks`, `lastClickedAt`; zero-click behavior; and `GET /api/links/missing` returning 404.
+- [ ] Run `go test ./internal/handlers -run 'TestGetLink|TestGetLinkAnalytics' -count=1`; expect failure because handlers and routes are missing.
+- [ ] Add `/api/links/:alias` and `/api/links/:alias/analytics` before slug routes. Lookup checks Redis, falls back to PostgreSQL, refills Redis, and produces JSON. Both endpoints return `{"error":"link not found"}` with 404 for `pgx.ErrNoRows` and a JSON 500 for database failures.
+- [ ] Run `go test ./internal/handlers -run 'TestGetLink|TestGetLinkAnalytics' -count=1`; expect pass.
+- [ ] Commit API changes with `feat: expose link lookup and analytics APIs`.
+
+### Task 3: Declarative and imperative tools
+
+**Files:** Create `web/webmcp.js`; modify `main.go` and `internal/handlers/link.go`; test `internal/handlers/link_test.go`.
+
+**Interfaces:** Consume both API URLs. Produce browser registrations of `resolve_short_link` and `get_link_analytics`.
+
+- [ ] Write a failing home-page test asserting `toolname="create_short_link"`, `tooldescription`, `toolautosubmit`, and `/web/webmcp.js`; test the script text for `document.modelContext`, both tool names, `inputSchema`, both API paths, and `readOnlyHint: true`.
+- [ ] Run `go test ./internal/handlers -run 'TestShowFormIncludesWebMCPMetadata|TestWebMCPScriptRegistersReadOnlyTools' -count=1`; expect failure.
+- [ ] Annotate the current form with `toolautosubmit`, the exact creation tool name and description, and input `toolparamdescription` limits. Serve `/web/webmcp.js` before slug routes and link it with `defer`.
+- [ ] In the script, wait for document readiness, return if `document.modelContext.registerTool` is unavailable, and register each read tool with `{type:'object',properties:{alias:{type:'string'}},required:['alias']}`, `annotations:{readOnlyHint:true}`, URL-encoded `fetch`, readable HTTP error extraction, and `JSON.stringify` results.
+- [ ] Re-run the task-three test command; expect pass.
+- [ ] Commit with `feat: register WebMCP link tools`.
+
+### Task 4: Documentation and verification
+
+**Files:** Modify `README.md`.
+
+- [ ] Document enabling `chrome://flags/#enable-webmcp-testing`, inspecting the three tools with Model Context Tool Inspector, and the create/resolve/traffic demo flow. State origin isolation and progressive enhancement requirements.
+- [ ] Run `go test ./internal/database ./internal/handlers -count=1` and `go vet ./...`; expect no failures.
+- [ ] Run `git diff --check`; expect no whitespace errors.
+- [ ] Commit with `docs: explain WebMCP testing`.
+
+## Plan Self-Review
+
+- Tasks 1–2 cover cache-aware lookup, aggregate-only analytics, and missing aliases.
+- Task 3 covers all three tool contracts and unsupported browsers.
+- Task 4 covers testing guidance and final verification.
+- Names and signatures are consistent across tasks; no dependencies or unrelated refactors are required.

--- a/docs/superpowers/specs/2026-09-01-webmcp-design.md
+++ b/docs/superpowers/specs/2026-09-01-webmcp-design.md
@@ -1,0 +1,62 @@
+# WebMCP integration design
+
+## Scope
+
+Expose the URL shortener's existing creation flow and two read-only capabilities
+to WebMCP-enabled browsers. The normal Fiber server-rendered UI remains the
+primary interface and works unchanged in browsers without WebMCP.
+
+The MVP excludes deletion and does not introduce a frontend framework, remote
+MCP server, authentication, or raw analytics event exposure.
+
+## Architecture
+
+The home form remains a `POST /` form handled by `CreateLinkForm`. WebMCP
+declarative attributes expose it as `create_short_link`; `toolautosubmit`
+submits the same form, so server-side validation and persistence remain the
+only source of truth.
+
+Two new read-only Fiber handlers provide JSON for the browser-side imperative
+tools:
+
+- `GET /api/links/:alias` returns the alias, generated short URL, and target
+  URL, or a JSON 404.
+- `GET /api/links/:alias/analytics` returns the alias, total click count, and
+  most recent click timestamp, or a JSON 404.
+
+The lookup handler follows the current Redis-then-PostgreSQL behavior. The
+analytics handler queries PostgreSQL for aggregate data only; IP addresses,
+User-Agent values, referrers, and individual events are never returned.
+
+The existing template embeds a small script. Once the page loads, it checks
+for `document.modelContext`; when available, it registers
+`resolve_short_link` and `get_link_analytics`. Each tool has a lowercase,
+action-oriented stable name, JSON Schema requiring `alias`, a descriptive
+purpose, and `annotations.readOnlyHint: true`. The tool fetches its JSON
+endpoint and returns a concise result; failed requests produce readable
+errors. In unsupported browsers the script is inert.
+
+## Data flow
+
+1. An agent invokes `create_short_link`; Chrome fills and submits the visible
+   form, and `CreateLinkForm` validates then saves the link as it already does.
+2. An agent invokes `resolve_short_link`; the registered script fetches the
+   lookup API and returns its normalized response.
+3. A redirect continues to append an internal JSONB click event.
+4. An agent invokes `get_link_analytics`; the script fetches an aggregate-only
+   response computed from that JSONB data.
+
+## Files and tests
+
+Expected production changes are `main.go`, `internal/handlers/link.go`, a new
+`internal/handlers/api.go`, `internal/database/postgres.go`, and `README.md`.
+Tests will cover the WebMCP form metadata, valid and missing API lookups,
+aggregate analytics including no clicks, and unchanged creation validation.
+
+## Error handling and compatibility
+
+JSON APIs return an explicit not-found result for unknown aliases. Imperative
+tools surface HTTP failures with the endpoint error message. Existing global
+and form rate limiters remain enabled. WebMCP registration is progressive
+enhancement only and cannot introduce a JavaScript error where the API is not
+implemented.

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -11,6 +11,16 @@ import (
 	"github.com/vitorhugo-java/go-link-shortener/internal/models"
 )
 
+type LinkDetails struct {
+	Slug        string
+	OriginalURL string
+}
+
+type LinkAnalytics struct {
+	TotalClicks   int
+	LastClickedAt *time.Time
+}
+
 //go:embed migrations/001_init.sql
 var migrationSQL string
 
@@ -47,6 +57,47 @@ func GetLinkURL(pool *pgxpool.Pool, slug string) (string, error) {
 		slug,
 	).Scan(&originalURL)
 	return originalURL, err
+}
+
+func GetLinkDetails(pool *pgxpool.Pool, slug string) (LinkDetails, error) {
+	var link LinkDetails
+	err := pool.QueryRow(
+		context.Background(),
+		`SELECT slug, original_url FROM links WHERE slug = $1`,
+		slug,
+	).Scan(&link.Slug, &link.OriginalURL)
+	return link, err
+}
+
+func GetLinkAnalytics(pool *pgxpool.Pool, slug string) (LinkAnalytics, error) {
+	var data []byte
+	err := pool.QueryRow(
+		context.Background(),
+		`SELECT analytics FROM links WHERE slug = $1`,
+		slug,
+	).Scan(&data)
+	if err != nil {
+		return LinkAnalytics{}, err
+	}
+	return decodeAnalyticsSummary(data)
+}
+
+func decodeAnalyticsSummary(data []byte) (LinkAnalytics, error) {
+	var events []struct {
+		Timestamp time.Time `json:"timestamp"`
+	}
+	if err := json.Unmarshal(data, &events); err != nil {
+		return LinkAnalytics{}, err
+	}
+
+	summary := LinkAnalytics{TotalClicks: len(events)}
+	for _, event := range events {
+		if summary.LastClickedAt == nil || event.Timestamp.After(*summary.LastClickedAt) {
+			timestamp := event.Timestamp
+			summary.LastClickedAt = &timestamp
+		}
+	}
+	return summary, nil
 }
 
 func AppendClickEvent(pool *pgxpool.Pool, slug string, event models.ClickEvent) {

--- a/internal/database/postgres_test.go
+++ b/internal/database/postgres_test.go
@@ -1,0 +1,38 @@
+package database
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDecodeAnalyticsSummaryCountsEventsAndFindsLatestTimestamp(t *testing.T) {
+	got, err := decodeAnalyticsSummary([]byte(`[
+		{"timestamp":"2026-09-01T14:20:00Z","ip":"192.0.2.1"},
+		{"timestamp":"2026-09-02T10:00:00Z","user_agent":"Example"}
+	]`))
+	if err != nil {
+		t.Fatalf("decode analytics: %v", err)
+	}
+	if got.TotalClicks != 2 {
+		t.Fatalf("total clicks = %d, want 2", got.TotalClicks)
+	}
+	if got.LastClickedAt == nil {
+		t.Fatal("last clicked at = nil, want timestamp")
+	}
+	if got.LastClickedAt.Format(time.RFC3339) != "2026-09-02T10:00:00Z" {
+		t.Fatalf("last clicked at = %s, want 2026-09-02T10:00:00Z", got.LastClickedAt.Format(time.RFC3339))
+	}
+}
+
+func TestDecodeAnalyticsSummaryReturnsEmptyAggregateForNoEvents(t *testing.T) {
+	got, err := decodeAnalyticsSummary([]byte(`[]`))
+	if err != nil {
+		t.Fatalf("decode analytics: %v", err)
+	}
+	if got.TotalClicks != 0 {
+		t.Fatalf("total clicks = %d, want 0", got.TotalClicks)
+	}
+	if got.LastClickedAt != nil {
+		t.Fatalf("last clicked at = %v, want nil", got.LastClickedAt)
+	}
+}

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/jackc/pgx/v5"
+)
+
+type linkResponse struct {
+	Alias     string `json:"alias"`
+	ShortURL  string `json:"shortUrl"`
+	TargetURL string `json:"targetUrl"`
+}
+
+type analyticsResponse struct {
+	Alias         string `json:"alias"`
+	TotalClicks   int    `json:"totalClicks"`
+	LastClickedAt any    `json:"lastClickedAt"`
+}
+
+func (h *Handler) GetLink(c fiber.Ctx) error {
+	link, err := h.lookupLink(c.Params("alias"))
+	if err != nil {
+		return apiError(c, err)
+	}
+	return c.JSON(linkResponse{
+		Alias:     link.Slug,
+		ShortURL:  fmt.Sprintf("%s://%s/%s", c.Scheme(), h.cfg.AppHost, link.Slug),
+		TargetURL: link.OriginalURL,
+	})
+}
+
+func (h *Handler) GetLinkAnalytics(c fiber.Ctx) error {
+	analytics, err := h.lookupAnalytics(c.Params("alias"))
+	if err != nil {
+		return apiError(c, err)
+	}
+	return c.JSON(analyticsResponse{
+		Alias:         c.Params("alias"),
+		TotalClicks:   analytics.TotalClicks,
+		LastClickedAt: analytics.LastClickedAt,
+	})
+}
+
+func apiError(c fiber.Ctx, err error) error {
+	if errors.Is(err, pgx.ErrNoRows) {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "link not found"})
+	}
+	return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+}

--- a/internal/handlers/api_test.go
+++ b/internal/handlers/api_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/jackc/pgx/v5"
+	"github.com/vitorhugo-java/go-link-shortener/internal/config"
+	"github.com/vitorhugo-java/go-link-shortener/internal/database"
+)
+
+func TestGetLinkReturnsAgentReadableLinkDetails(t *testing.T) {
+	h := &Handler{
+		cfg: &config.Config{AppHost: "short.example"},
+		lookupLink: func(alias string) (database.LinkDetails, error) {
+			if alias != "webmcp" {
+				t.Fatalf("lookup alias = %q, want webmcp", alias)
+			}
+			return database.LinkDetails{Slug: "webmcp", OriginalURL: "https://developer.chrome.com/docs/ai/webmcp"}, nil
+		},
+	}
+	app := fiber.New()
+	app.Get("/api/links/:alias", h.GetLink)
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/api/links/webmcp", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got struct {
+		Alias     string `json:"alias"`
+		ShortURL  string `json:"shortUrl"`
+		TargetURL string `json:"targetUrl"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Alias != "webmcp" || got.ShortURL != "http://short.example/webmcp" || got.TargetURL != "https://developer.chrome.com/docs/ai/webmcp" {
+		t.Fatalf("response = %#v", got)
+	}
+}
+
+func TestGetLinkAnalyticsReturnsAggregateOnly(t *testing.T) {
+	lastClicked := time.Date(2026, time.September, 1, 14, 20, 0, 0, time.UTC)
+	h := &Handler{
+		lookupAnalytics: func(alias string) (database.LinkAnalytics, error) {
+			return database.LinkAnalytics{TotalClicks: 42, LastClickedAt: &lastClicked}, nil
+		},
+	}
+	app := fiber.New()
+	app.Get("/api/links/:alias/analytics", h.GetLinkAnalytics)
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/api/links/webmcp/analytics", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	var got map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got["alias"] != "webmcp" || got["totalClicks"] != float64(42) || got["lastClickedAt"] != "2026-09-01T14:20:00Z" {
+		t.Fatalf("response = %#v", got)
+	}
+	if _, ok := got["ip"]; ok {
+		t.Fatalf("response exposes IP: %#v", got)
+	}
+}
+
+func TestGetLinkReturnsNotFoundForUnknownAlias(t *testing.T) {
+	h := &Handler{
+		lookupLink: func(string) (database.LinkDetails, error) { return database.LinkDetails{}, pgx.ErrNoRows },
+	}
+	app := fiber.New()
+	app.Get("/api/links/:alias", h.GetLink)
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/api/links/missing", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/internal/handlers/link.go
+++ b/internal/handlers/link.go
@@ -108,25 +108,42 @@ button:hover{background:#2ea043}
 <div class="card">
   <h1>&#128279; Encurtador de Links</h1>
   %s
-  <form method="POST" action="/">
+  <form method="POST" action="/" toolautosubmit toolname="create_short_link" tooldescription="Create a short URL with a user-provided alias that redirects to an HTTP or HTTPS URL.">
     <label for="url">URL a encurtar</label>
-    <input id="url" name="url" type="text" placeholder="https://exemplo.com/link-longo" value="%s" required>
+    <input id="url" name="url" type="text" placeholder="https://exemplo.com/link-longo" value="%s" maxlength="2048" required toolparamdescription="Target HTTP or HTTPS URL, required, maximum 2048 characters.">
     <label for="alias">Alias desejado</label>
-    <input id="alias" name="alias" type="text" placeholder="meu-link" value="%s" maxlength="100" required>
+    <input id="alias" name="alias" type="text" placeholder="meu-link" value="%s" maxlength="100" required toolparamdescription="Alias using only letters, numbers, and hyphens; required, maximum 100 characters.">
     <button type="submit">Encurtar</button>
   </form>
 </div>
+<script src="/web/webmcp.js" defer></script>
 </body>
 </html>`
 
 type Handler struct {
-	pg  *pgxpool.Pool
-	rdb *redis.Client
-	cfg *config.Config
+	pg              *pgxpool.Pool
+	rdb             *redis.Client
+	cfg             *config.Config
+	lookupLink      func(string) (database.LinkDetails, error)
+	lookupAnalytics func(string) (database.LinkAnalytics, error)
 }
 
 func New(pg *pgxpool.Pool, rdb *redis.Client, cfg *config.Config) *Handler {
-	return &Handler{pg: pg, rdb: rdb, cfg: cfg}
+	h := &Handler{pg: pg, rdb: rdb, cfg: cfg}
+	h.lookupLink = func(alias string) (database.LinkDetails, error) {
+		if targetURL, err := database.CacheGet(h.rdb, alias); err == nil && targetURL != "" {
+			return database.LinkDetails{Slug: alias, OriginalURL: targetURL}, nil
+		}
+		link, err := database.GetLinkDetails(h.pg, alias)
+		if err == nil {
+			_ = database.CacheSet(h.rdb, link.Slug, link.OriginalURL)
+		}
+		return link, err
+	}
+	h.lookupAnalytics = func(alias string) (database.LinkAnalytics, error) {
+		return database.GetLinkAnalytics(h.pg, alias)
+	}
+	return h
 }
 
 func (h *Handler) ShowForm(c fiber.Ctx) error {

--- a/internal/handlers/link_test.go
+++ b/internal/handlers/link_test.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/vitorhugo-java/go-link-shortener/internal/config"
+)
+
+func TestShowFormExposesCreateShortLinkAsDeclarativeTool(t *testing.T) {
+	app := fiber.New()
+	app.Get("/", (&Handler{cfg: &config.Config{}}).ShowForm)
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	for _, want := range []string{"toolname=\"create_short_link\"", "toolautosubmit", "tooldescription=\"Create a short URL", "toolparamdescription=\"Target HTTP or HTTPS URL", "maxlength=\"2048\"", "toolparamdescription=\"Alias using only letters, numbers, and hyphens"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("home page does not expose %q", want)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "embed"
 	"log"
 	"time"
 
@@ -10,6 +11,9 @@ import (
 	"github.com/vitorhugo-java/go-link-shortener/internal/database"
 	"github.com/vitorhugo-java/go-link-shortener/internal/handlers"
 )
+
+//go:embed web/webmcp.js
+var webMCPScript string
 
 func main() {
 	cfg := config.Load()
@@ -45,6 +49,12 @@ func main() {
 
 	app.Get("/", h.ShowForm)
 	app.Post("/", formLimiter, h.CreateLinkForm)
+	app.Get("/api/links/:alias/analytics", h.GetLinkAnalytics)
+	app.Get("/api/links/:alias", h.GetLink)
+	app.Get("/web/webmcp.js", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderContentType, "application/javascript; charset=utf-8")
+		return c.SendString(webMCPScript)
+	})
 	app.Get("/:slug", h.RedirectLink)
 	app.Get("/:slug/*", h.CreateLink)
 

--- a/web/webmcp.js
+++ b/web/webmcp.js
@@ -1,0 +1,50 @@
+(function () {
+  async function fetchToolResult(path, alias, suffix, signal) {
+    const response = await fetch(path + encodeURIComponent(alias) + suffix, { signal: signal });
+    const payload = await response.json().catch(function () { return {}; });
+    if (!response.ok) {
+      throw new Error(payload.error || "Unable to complete the link request.");
+    }
+    return JSON.stringify(payload);
+  }
+
+  async function registerTools() {
+    if (!document.modelContext || typeof document.modelContext.registerTool !== "function") {
+      return;
+    }
+
+    const inputSchema = {
+      type: "object",
+      properties: {
+        alias: { type: "string", description: "The short-link alias to look up." }
+      },
+      required: ["alias"]
+    };
+
+    await document.modelContext.registerTool({
+      name: "resolve_short_link",
+      description: "Look up a short link and return its short URL and destination URL. Use this when a user asks where an alias redirects.",
+      inputSchema: inputSchema,
+      annotations: { readOnlyHint: true },
+      execute: function (input, context) {
+        return fetchToolResult("/api/links/", input.alias, "", context && context.signal);
+      }
+    });
+
+    await document.modelContext.registerTool({
+      name: "get_link_analytics",
+      description: "Get aggregate click metrics for a short-link alias. Use this when a user asks about link traffic.",
+      inputSchema: inputSchema,
+      annotations: { readOnlyHint: true },
+      execute: function (input, context) {
+        return fetchToolResult("/api/links/", input.alias, "/analytics", context && context.signal);
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", registerTools, { once: true });
+  } else {
+    registerTools();
+  }
+}());

--- a/web/webmcp.test.mjs
+++ b/web/webmcp.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import vm from 'node:vm';
+
+async function loadTools(fetchImpl) {
+  const registrations = [];
+  const listeners = new Map();
+  const document = {
+    readyState: 'complete',
+    addEventListener(type, listener) { listeners.set(type, listener); },
+    modelContext: { registerTool: async (tool) => registrations.push(tool) },
+  };
+  const source = await readFile(new URL('./webmcp.js', import.meta.url), 'utf8');
+  vm.runInNewContext(source, { document, fetch: fetchImpl, encodeURIComponent, JSON, Error });
+
+  // registerTools awaits each registration; let both promise continuations run.
+  await new Promise(setImmediate);
+  await new Promise(setImmediate);
+  return registrations;
+}
+
+test('registers the two read-only link tools', async () => {
+  const tools = await loadTools(async () => ({ ok: true, json: async () => ({}) }));
+  assert.deepEqual(tools.map((tool) => tool.name), ['resolve_short_link', 'get_link_analytics']);
+  for (const tool of tools) {
+    assert.equal(tool.annotations.readOnlyHint, true);
+    assert.deepEqual(Array.from(tool.inputSchema.required), ['alias']);
+  }
+});
+
+test('resolve tool encodes aliases and returns the API payload', async () => {
+  let requestedURL;
+  const tools = await loadTools(async (url) => {
+    requestedURL = url;
+    return { ok: true, json: async () => ({ alias: 'hello-world', shortUrl: 'http://short/hello-world', targetUrl: 'https://example.com' }) };
+  });
+  const result = await tools[0].execute({ alias: 'hello world' });
+  assert.equal(requestedURL, '/api/links/hello%20world');
+  assert.equal(result, '{"alias":"hello-world","shortUrl":"http://short/hello-world","targetUrl":"https://example.com"}');
+});
+
+test('analytics tool requests the aggregate endpoint for the encoded alias', async () => {
+  let requestedURL;
+  const tools = await loadTools(async (url) => {
+    requestedURL = url;
+    return { ok: true, json: async () => ({ alias: 'hello-world', totalClicks: 42, lastClickedAt: '2026-09-01T14:20:00Z' }) };
+  });
+  const result = await tools[1].execute({ alias: 'hello world' });
+  assert.equal(requestedURL, '/api/links/hello%20world/analytics');
+  assert.equal(result, '{"alias":"hello-world","totalClicks":42,"lastClickedAt":"2026-09-01T14:20:00Z"}');
+});


### PR DESCRIPTION
- **docs: add WebMCP integration design**
- **docs: add WebMCP implementation plan**
- **chore: ignore local worktrees**
- **feat: expose link tools through WebMCP**
